### PR TITLE
Add Collision AABB chunk

### DIFF
--- a/src/Pure3D/Chunks/CollisionAABB.cs
+++ b/src/Pure3D/Chunks/CollisionAABB.cs
@@ -1,0 +1,24 @@
+using System.IO;
+
+namespace Pure3D.Chunks
+{
+    [ChunkType(117506054)]
+    public class CollisionAABB : Chunk
+    {
+
+        public CollisionAABB(File file, uint type) : base(file, type)
+        {
+        }
+
+        public override void ReadHeader(Stream stream, long length)
+        {
+            BinaryReader reader = new(stream);
+            reader.ReadUInt32(); // For some reason, there are 4 bytes here that do nothing
+        }
+
+        public override string ToString()
+        {
+            return "Collision Axis-Aligned Bounding Box";
+        }
+    }
+}


### PR DESCRIPTION
The chunk contains 4 bytes of data that apparently do nothing at all. As far as I know, it could be an attribute detailing the chunk's version, but I'm unsure on that.